### PR TITLE
Fix data protocol logic when creating LIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ This resource has the following action:
 ### Attributes ###
 This resource has the following attributes:
 
-* `code` string, license code when adding a package. 24 or 48 uppercase alpha only characters.
+* `codes` Array, license code when adding a package. 24 or 48 uppercase alpha only characters.
 
 ### Example ###
 
 ````ruby
 netapp_feature 'iscsi' do
-  code 'ABCDEFGHIJKLMNOPQRSTUVWX'
+  codes ['ABCDEFGHIJKLMNOPQRSTUVWX']
   action :enable
 end
 ````


### PR DESCRIPTION
This fixes the incorrect API call when creating a data LIF to have
a nested data-protocol NaElement for each supported protocol. In
addition, there is now enforcement of the protocols that can be
concurrently applied to any given LIF.