### PR TITLE
New error code and refactor

### DIFF
--- a/libraries/netapp_api.rb
+++ b/libraries/netapp_api.rb
@@ -76,9 +76,10 @@ module NetApp
     def check_errors!(result, resource, action)
       if result.results_errno == 0  # The Api ran successfully and returned no error.
         return true
-      elsif result.results_errno == "17" || result.results_errno == "9012" || result.results_errno == "14922" || result.results_errno == "13130" || result.results_errno ==  "13080" || result.results_errno == "13001" || result.results_errno ==  "15698" || result.results_errno == "15661" || result.results_errno ==  "13040"
+      elsif [EONTAPI_EEXIST, EVDISK_ERROR_VDISK_EXISTS, EVSERVERNAMEEXISTS, 13130, EQTREEEXISTS, EAPIERROR, EVSERVERNOTFOUND, EOBJECTNOTFOUND, EVOLUMEDOESNOTEXIST, EVOLEXISTS].include? result.results_errno.to_i
         #If the resource already exists, then ignore the error and proceed with the next resource.
         #Do not update resource count.
+        Chef::Log.debug "Ignoring NetApp API error: #{resource} #{action} failed.Error no- #{result.results_errno}. Reason- #{result.results_reason}."
         return false
       else
         raise "#{resource} #{action} failed.Error no- #{result.results_errno}. Reason- #{result.results_reason}."


### PR DESCRIPTION
Somewhere between NetApp 7.x and 9.4 creating a volume that already
existed changed from returning code 17 to 17159. So added that in to the
list and refactored to use the constant names from the netapp library
instead of numbers.

Incidentally, 13130 does not have a documented name but is used when you
try to create an export policy that already exists.

I do not understand the full list of error codes. For example we're
checking for both "volume exists" and "volume does not exist" as
acceptable error codes. Perhaps that's for the delete case (e.g. trying
to delete a volume that doesn't exist is not an error?)

Signed-off-by: Sean Walberg <sean@ertw.com>